### PR TITLE
ADD: mac addresses into L2 parsing

### DIFF
--- a/demo/flows_summary/flows_summary.c
+++ b/demo/flows_summary/flows_summary.c
@@ -194,7 +194,7 @@ int main(int argc, char** argv)
     }
 
     pfwl_state_t* state = pfwl_init();
-    pfwl_set_flow_termination_callback(state, &summarizer);
+    pfwl_set_flow_termination_callback(state, &summarizer);    
     print_header();
     pfwl_dissection_info_t r;
     pfwl_protocol_l2_t dlt = pfwl_convert_pcap_dlt(pcap_datalink(handle));

--- a/include/peafowl/peafowl.h
+++ b/include/peafowl/peafowl.h
@@ -521,6 +521,8 @@ typedef struct pfwl_flow_info {
 typedef struct pfwl_dissection_info_l2 {
   size_t length;               ///< Length of L2 header
   pfwl_protocol_l2_t protocol; ///< L2 (datalink) protocol
+  uint8_t mac_src[6];           ///< source MAC address 
+  uint8_t mac_dst[6];           ///< dest MAC address
 }pfwl_dissection_info_l2_t;
 
 /**

--- a/src/parsing_l2.c
+++ b/src/parsing_l2.c
@@ -247,6 +247,9 @@ pfwl_status_t pfwl_dissect_L2(const unsigned char *packet,
     ether_header = (struct ether_header *) (packet);
     // set datalink offset
     dlink_offset = ETHHDR_SIZE;
+    // assign MAC to l2 structure dissection info
+    memcpy(dissection_info->l2.mac_src, ether_header->ether_shost, ETH_ALEN);
+    memcpy(dissection_info->l2.mac_dst, ether_header->ether_dhost, ETH_ALEN);
     type = ntohs(ether_header->ether_type);
     if (type <= 1500)
       eth_type_1 = 1; // ethernet I - followed by llc snap 05DC


### PR DESCRIPTION
**NOTE**
When `pfwl_dissect_from_L2` return, the structure `r` does not show the correct mac addresses parsed rom the pkt.
**Must be checked**