### PR TITLE
Flow expiration bucket calculation error leading to segfault

### DIFF
--- a/demo/flows_summary/flows_summary.cpp
+++ b/demo/flows_summary/flows_summary.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv){
   while((packet = pcap_next(handle, &header)) != NULL){
     std::string pkt;
     pkt.assign((const char*) packet, header.caplen);
-    peafowl::DissectionInfo r = pfwl->dissectFromL2(pkt, time(NULL), dlt);
+    peafowl::DissectionInfo r = pfwl->dissectFromL2(pkt, header.ts.tv_sec, dlt);
     if(!r.getStatus().isError()){
       if(r.getL4().getProtocol() == IPPROTO_TCP ||
          r.getL4().getProtocol() == IPPROTO_UDP){


### PR DESCRIPTION
The bucket_id is calculated from the current packet's timestamp, while the old_bucket_id is calculated off the latest timestamp of ingress and egress streams. This may result in a flow being inserted in two expiration buckets if packets come out of order (later packet's timestamp is earlier than the previously recorded PFWL_STAT_TIMESTAMP_LAST) leading to segfault on expiration bucket cleanup