### PR TITLE
fix compile error 'missing pcap.h' by using PCAP_INCLUDE_DIR value

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${CMAKE_SOURCE_DIR}/include)
 if (PCAP_FOUND)
 	link_directories(${PCAP_LIBRARY})
-	include_directories($PCAP_INCLUDE_DIR)
+	include_directories(${PCAP_INCLUDE_DIR})
 	add_subdirectory(protocol_identification)
 	add_subdirectory(dump_jpeg)
 	add_subdirectory(sip_extraction)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ file(GLOB SOURCES "*.cpp" "*.c" "inspectors/*.cpp" "inspectors/*.c" "external/md
 list(REMOVE_ITEM SOURCES "${CMAKE_SOURCE_DIR}/src/worker.cpp" "${CMAKE_SOURCE_DIR}/src/peafowl_mc.cpp" "${CMAKE_SOURCE_DIR}/src/peafowl_py.cpp")
 
 if (PCAP_FOUND)
-  include_directories($PCAP_INCLUDE_DIR)
+  include_directories(${PCAP_INCLUDE_DIR})
   add_definitions(-DHAVE_PCAP)
 endif(PCAP_FOUND)
 


### PR DESCRIPTION
Currently it expands to -I"/home/boris/peafowl-1.0.0/demo/\$PCAP_INCLUDE_DIR".